### PR TITLE
Allow callable values in template

### DIFF
--- a/lib/classes/Template.php
+++ b/lib/classes/Template.php
@@ -438,6 +438,8 @@ class Template {
 			$aText[] = sprintf('%f', $mText);
 		} else if(is_numeric($mText)) {
 			$aText[] = sprintf('%d', $mText);
+		} else if (is_callable($mText)) {
+			$aText = $this->getTextForReplaceIdentifier($mText(), $iFlags);
 		} else if(is_object($mText)) {
 			$sObjectDescription = Util::descriptionForObject($mText);
 			if(!$sObjectDescription) {

--- a/lib/tests/TemplateReplacementTypeTests.php
+++ b/lib/tests/TemplateReplacementTypeTests.php
@@ -28,6 +28,22 @@ class TemplateReplacementTypeTests extends PHPUnit_Framework_TestCase {
 		$this->assertSame("true", $oTestTemplate->render());
 	}
 	
+	public function testCallableReplace() {
+		$oTestTemplate = new Template('{{test}}', null, true);
+		$oTestTemplate->replaceIdentifier('test', function() {
+			return 1;
+		});
+		$this->assertSame("1", $oTestTemplate->render());
+	}
+	
+	public function testStringNotCallableReplace() {
+		$oTestTemplate = new Template('{{test}}', null, true);
+		$cFunction = create_function('', 'return "gaga";');
+		$oTestTemplate->replaceIdentifier('test', $cFunction);
+		$this->assertNotEquals("gaga", $oTestTemplate->render());
+		$this->assertSame((string)$cFunction, $oTestTemplate->render());
+	}
+	
 	public function testBooleanFalseReplace() {
 		$oTestTemplate = new Template('{{test}}', null, true);
 		$oTestTemplate->replaceIdentifier('test', false);


### PR DESCRIPTION
I’ve had a problem with the navigation and the boolean parser of which we turned some slow expressions into closures so they would only be evaluated when needed. Since we also pass all boolean parser variables to the template, the template also needs to be able to evaluate these.
