### PR TITLE
implement isOutdated() in DocumentListFrontendModule

### DIFF
--- a/modules/frontend/document_list/DocumentListFrontendModule.php
+++ b/modules/frontend/document_list/DocumentListFrontendModule.php
@@ -3,7 +3,7 @@
  * @package modules.frontend
  */
 
-class DocumentListFrontendModule extends DynamicFrontendModule {
+class DocumentListFrontendModule extends FrontendModule {
 
 	const LIST_ITEM_POSTFIX = '_item';
 	const SORT_BY_NAME = 'by_name';
@@ -25,6 +25,10 @@ class DocumentListFrontendModule extends DynamicFrontendModule {
 			$oListTemplate = new Template("", null, true);
 		}
 		return $oListTemplate;
+	}
+
+	public function isOutdated($oCache) {
+		return $oCache->isOlderThan(DocumentQuery::create());
 	}
 
 	public static function listQuery($aOptions) {


### PR DESCRIPTION
• this fixes cache handling for documents that have been updated without changing the configuration
  previously even changing the configuration did not clear the caches of the related documents
  NOTE: it looks like it behaves now as follows
  • replacing a file in document_detail with drag and drop without saving the document_detail deliberately requires a clear caches in admin or shift reload of browser
  • additionally saving the document_detail seems to work immediately