### PR TITLE
Allow null owner_id for links

### DIFF
--- a/config/schema.xml
+++ b/config/schema.xml
@@ -366,7 +366,7 @@
 	<foreign-key foreignTable="languages">
 		<reference local="language_id" foreign="id" />
 	</foreign-key>
-	<column name="owner_id" type="integer" required="true" />
+	<column name="owner_id" type="integer" required="false" default="null"/>
 	<foreign-key foreignTable="users">
 		<reference local="owner_id" foreign="id" />
 	</foreign-key>

--- a/data/migrations/PropelMigration_1545301289.php
+++ b/data/migrations/PropelMigration_1545301289.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * Data object containing the SQL and PHP code to migrate the database
+ * up to version 1545301289.
+ * Generated on 2018-12-20 11:21:29 by rafi
+ */
+class PropelMigration_1545301289
+{
+
+    public function preUp($manager)
+    {
+        // add the pre-migration code here
+    }
+
+    public function postUp($manager)
+    {
+        // add the post-migration code here
+    }
+
+    public function preDown($manager)
+    {
+        // add the pre-migration code here
+    }
+
+    public function postDown($manager)
+    {
+        // add the post-migration code here
+    }
+
+    /**
+     * Get the SQL statements for the Up migration
+     *
+     * @return array list of the SQL strings to execute for the Up migration
+     *               the keys being the datasources
+     */
+    public function getUpSQL()
+    {
+        return array (
+  'rapila' => '
+# This is a fix for InnoDB in MySQL >= 4.1.x
+# It "suspends judgement" for fkey relationships until are tables are set.
+SET FOREIGN_KEY_CHECKS = 0;
+
+ALTER TABLE `links` CHANGE `owner_id` `owner_id` INTEGER;
+
+# This restores the fkey checks, after having unset them earlier
+SET FOREIGN_KEY_CHECKS = 1;
+',
+);
+    }
+
+    /**
+     * Get the SQL statements for the Down migration
+     *
+     * @return array list of the SQL strings to execute for the Down migration
+     *               the keys being the datasources
+     */
+    public function getDownSQL()
+    {
+        return array (
+  'rapila' => '
+# This is a fix for InnoDB in MySQL >= 4.1.x
+# It "suspends judgement" for fkey relationships until are tables are set.
+SET FOREIGN_KEY_CHECKS = 0;
+
+ALTER TABLE `links` CHANGE `owner_id` `owner_id` INTEGER NOT NULL;
+
+# This restores the fkey checks, after having unset them earlier
+SET FOREIGN_KEY_CHECKS = 1;
+',
+);
+    }
+
+}

--- a/data/sql/mysql/rapila.schema.sql
+++ b/data/sql/mysql/rapila.schema.sql
@@ -506,7 +506,7 @@ CREATE TABLE `links`
     `url` VARCHAR(255),
     `description` VARCHAR(255),
     `language_id` VARCHAR(3),
-    `owner_id` INTEGER NOT NULL,
+    `owner_id` INTEGER,
     `link_category_id` INTEGER,
     `sort` INTEGER,
     `is_private` TINYINT(1) DEFAULT 0,

--- a/lib/classes/CachingStrategyFile.php
+++ b/lib/classes/CachingStrategyFile.php
@@ -49,6 +49,15 @@ class CachingStrategyFile extends CachingStrategy {
 		}
 	}
 
+	public function pass(Cache $oCache) {
+		$sPath = $this->getFilePath($oCache);
+		$rFile = fopen($sPath, 'rb');
+		@flock($rFile, LOCK_SH);
+		fpassthru($rFile);
+		@flock($rFile, LOCK_UN);
+		fclose($rFile);
+	}
+
 	public function write(Cache $oCache, $sEntry, $bAppend = false) {
 		$sPath = $this->prepareFilePath($oCache);
 		return file_put_contents($this->getFilePath($oCache), $sEntry, $bAppend ? FILE_APPEND | LOCK_EX : LOCK_EX);

--- a/lib/classes/CachingStrategyFile.php
+++ b/lib/classes/CachingStrategyFile.php
@@ -25,10 +25,19 @@ class CachingStrategyFile extends CachingStrategy {
 	public function exists(Cache $oCache) {
 		return file_exists($this->getFilePath($oCache));
 	}
+
+	private static function blockingRead($sPath) {
+		$rFile = fopen($sPath, 'rb');
+		@flock($rFile, LOCK_SH);
+		$sContents = file_get_contents($sPath);
+		@flock($rFile, LOCK_UN);
+		fclose($rFile);
+		return $sContents;
+}
 	
 	public function read(Cache $oCache) {
 		$sPath = $this->getFilePath($oCache);
-		return file_get_contents($sPath);
+		return self::blockingRead($sPath);
 	}
 	
 	public function readData(Cache $oCache) {
@@ -36,13 +45,13 @@ class CachingStrategyFile extends CachingStrategy {
 		if($this->use_var_export) {
 			return include($sPath);
 		} else {
-			return unserialize(file_get_contents($sPath));
+			return unserialize(self::blockingRead($sPath));
 		}
 	}
 
 	public function write(Cache $oCache, $sEntry, $bAppend = false) {
 		$sPath = $this->prepareFilePath($oCache);
-		return file_put_contents($this->getFilePath($oCache), $sEntry, $bAppend ? FILE_APPEND : 0);
+		return file_put_contents($this->getFilePath($oCache), $sEntry, $bAppend ? FILE_APPEND | LOCK_EX : LOCK_EX);
 	}
 
 	public function writeData(Cache $oCache, $mEntry, $bAppend = false) {

--- a/lib/model/map/LinkTableMap.php
+++ b/lib/model/map/LinkTableMap.php
@@ -43,7 +43,7 @@ class LinkTableMap extends TableMap
         $this->addColumn('url', 'Url', 'VARCHAR', false, 255, null);
         $this->addColumn('description', 'Description', 'VARCHAR', false, 255, null);
         $this->addForeignKey('language_id', 'LanguageId', 'VARCHAR', 'languages', 'id', false, 3, null);
-        $this->addForeignKey('owner_id', 'OwnerId', 'INTEGER', 'users', 'id', true, null, null);
+        $this->addForeignKey('owner_id', 'OwnerId', 'INTEGER', 'users', 'id', false, null, null);
         $this->addForeignKey('link_category_id', 'LinkCategoryId', 'INTEGER', 'link_categories', 'id', false, null, null);
         $this->addColumn('sort', 'Sort', 'INTEGER', false, null, null);
         $this->addColumn('is_private', 'IsPrivate', 'BOOLEAN', false, 1, false);

--- a/lib/model/om/BaseLinkQuery.php
+++ b/lib/model/om/BaseLinkQuery.php
@@ -882,7 +882,7 @@ abstract class BaseLinkQuery extends ModelCriteria
      *
      * @return LinkQuery The current query, for fluid interface
      */
-    public function joinUserRelatedByOwnerId($relationAlias = null, $joinType = Criteria::INNER_JOIN)
+    public function joinUserRelatedByOwnerId($relationAlias = null, $joinType = Criteria::LEFT_JOIN)
     {
         $tableMap = $this->getTableMap();
         $relationMap = $tableMap->getRelation('UserRelatedByOwnerId');
@@ -917,7 +917,7 @@ abstract class BaseLinkQuery extends ModelCriteria
      *
      * @return   UserQuery A secondary query class using the current class as primary query
      */
-    public function useUserRelatedByOwnerIdQuery($relationAlias = null, $joinType = Criteria::INNER_JOIN)
+    public function useUserRelatedByOwnerIdQuery($relationAlias = null, $joinType = Criteria::LEFT_JOIN)
     {
         return $this
             ->joinUserRelatedByOwnerId($relationAlias, $joinType)

--- a/lib/model/om/BaseUser.php
+++ b/lib/model/om/BaseUser.php
@@ -2020,9 +2020,10 @@ abstract class BaseUser extends BaseObject implements Persistent
 
             if ($this->linksRelatedByOwnerIdScheduledForDeletion !== null) {
                 if (!$this->linksRelatedByOwnerIdScheduledForDeletion->isEmpty()) {
-                    LinkQuery::create()
-                        ->filterByPrimaryKeys($this->linksRelatedByOwnerIdScheduledForDeletion->getPrimaryKeys(false))
-                        ->delete($con);
+                    foreach ($this->linksRelatedByOwnerIdScheduledForDeletion as $linkRelatedByOwnerId) {
+                        // need to save related object because we set the relation to null
+                        $linkRelatedByOwnerId->save($con);
+                    }
                     $this->linksRelatedByOwnerIdScheduledForDeletion = null;
                 }
             }
@@ -5771,7 +5772,7 @@ abstract class BaseUser extends BaseObject implements Persistent
                 $this->linksRelatedByOwnerIdScheduledForDeletion = clone $this->collLinksRelatedByOwnerId;
                 $this->linksRelatedByOwnerIdScheduledForDeletion->clear();
             }
-            $this->linksRelatedByOwnerIdScheduledForDeletion[]= clone $linkRelatedByOwnerId;
+            $this->linksRelatedByOwnerIdScheduledForDeletion[]= $linkRelatedByOwnerId;
             $linkRelatedByOwnerId->setUserRelatedByOwnerId(null);
         }
 

--- a/lib/model/om/BaseUserQuery.php
+++ b/lib/model/om/BaseUserQuery.php
@@ -1424,7 +1424,7 @@ abstract class BaseUserQuery extends ModelCriteria
      *
      * @return UserQuery The current query, for fluid interface
      */
-    public function joinLinkRelatedByOwnerId($relationAlias = null, $joinType = Criteria::INNER_JOIN)
+    public function joinLinkRelatedByOwnerId($relationAlias = null, $joinType = Criteria::LEFT_JOIN)
     {
         $tableMap = $this->getTableMap();
         $relationMap = $tableMap->getRelation('LinkRelatedByOwnerId');
@@ -1459,7 +1459,7 @@ abstract class BaseUserQuery extends ModelCriteria
      *
      * @return   LinkQuery A secondary query class using the current class as primary query
      */
-    public function useLinkRelatedByOwnerIdQuery($relationAlias = null, $joinType = Criteria::INNER_JOIN)
+    public function useLinkRelatedByOwnerIdQuery($relationAlias = null, $joinType = Criteria::LEFT_JOIN)
     {
         return $this
             ->joinLinkRelatedByOwnerId($relationAlias, $joinType)

--- a/modules/frontend/document_list/DocumentListFrontendModule.php
+++ b/modules/frontend/document_list/DocumentListFrontendModule.php
@@ -3,7 +3,7 @@
  * @package modules.frontend
  */
 
-class DocumentListFrontendModule extends DynamicFrontendModule {
+class DocumentListFrontendModule extends FrontendModule {
 
 	const LIST_ITEM_POSTFIX = '_item';
 	const SORT_BY_NAME = 'by_name';
@@ -25,6 +25,10 @@ class DocumentListFrontendModule extends DynamicFrontendModule {
 			$oListTemplate = new Template("", null, true);
 		}
 		return $oListTemplate;
+	}
+
+	public function isOutdated($oCache) {
+		return $oCache->isOlderThan(DocumentQuery::create());
 	}
 
 	public static function listQuery($aOptions) {


### PR DESCRIPTION
I don’t really know why we added the owner_id to links and documents (we never used it AFAIK).

We did set it to allow null on documents at some point but on links, not setting it was still denied (`General error: 1364 Field 'owner_id' doesn't have a default value`).

Does one of you know more about that?