### PR TITLE
Allow multiple use of page identifier

### DIFF
--- a/modules/widget/page_detail/PageDetailWidgetModule.php
+++ b/modules/widget/page_detail/PageDetailWidgetModule.php
@@ -148,6 +148,8 @@ class PageDetailWidgetModule extends PersistentWidgetModule {
 		foreach($oPage->getPagePropertyQuery()->byNamespace(false)->find() as $oPageProperty) {
 			if(isset($aResult[$oPageProperty->getName()])) {
 				$aResult[$oPageProperty->getName()]['value'] = $oPageProperty->getValue();
+			}	else {
+				$aResult[$oPageProperty->getName()] = array('value' => $oPageProperty->getValue(), 'defaultValue' => null, 'type' => null);
 			}
 		}
 		$aResult['page_identifier'] = array('value' => $oPage->getIdentifier(), 'defaultValue' => null, 'type' => null);

--- a/modules/widget/page_detail/PageDetailWidgetModule.php
+++ b/modules/widget/page_detail/PageDetailWidgetModule.php
@@ -138,28 +138,22 @@ class PageDetailWidgetModule extends PersistentWidgetModule {
 	private function getAvailablePageProperties($oPage) {
 		$aAvailablePageProperties = $oPage->getTemplate()->identifiersMatching('pageProperty', Template::$ANY_VALUE);
 		$aResult = array();
-		$aSetProperties = array();
-		foreach($oPage->getPagePropertyQuery()->byNamespace(false)->find() as $oPageProperty) {
-			$aSetProperties[$oPageProperty->getName()] = $oPageProperty->getValue();
-		}
+
 		foreach($aAvailablePageProperties as $oProperty) {
 			$sPropertyName = $oProperty->getValue();
-
-			$aResult[$sPropertyName]['value'] = isset($aSetProperties[$sPropertyName]) ? $aSetProperties[$sPropertyName] : '';
+			$aResult[$sPropertyName]['value'] = '';
 			$aResult[$sPropertyName]['defaultValue'] = $oProperty->getParameter('defaultValue');
 			$aResult[$sPropertyName]['type'] = $oProperty->getParameter('propertyType');
-
-			unset($aSetProperties[$sPropertyName]);
 		}
-		foreach($aSetProperties as $sRemainingPropertyName => $sRemainingPropertyValue) {
-			$aResult[$sRemainingPropertyName] = array('value' => $sRemainingPropertyValue, 'defaultValue' => null, 'type' => null);
+		foreach($oPage->getPagePropertyQuery()->byNamespace(false)->find() as $oPageProperty) {
+			if(isset($aResult[$oPageProperty->getName()])) {
+				$aResult[$oPageProperty->getName()]['value'] = $oPageProperty->getValue();
+			}
 		}
 		$aResult['page_identifier'] = array('value' => $oPage->getIdentifier(), 'defaultValue' => null, 'type' => null);
-
 		foreach($aResult as $sName => &$aValues) {
 			$aValues['display_name'] = TranslationPeer::getString("page_property.$sName", null, StringUtil::makeReadableName($sName));
 		}
-
 		return $aResult;
 	}
 


### PR DESCRIPTION
• for example for replacing meta robots and googlebot, maybe there could be other usages

Like this different identifiers could be replaced by different page_properties or the same. More flexibility, and easier to administer.

In case nobody sees negative consequences, I would like to merge this into master.